### PR TITLE
Targeted config update

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Usage for this services is:
 
 If you update configuration, but don't want to completely overwrite existing configuration on sites, use this method to do a targeted update of configuration.
 
-It works much like installConfig, but you need to pass in a "$targets" variable as well, which is an array of paths to the part of the configuration that you want to install, using ':' as a separator.
+It works much like installConfig, but you need to pass in a "$targets" variable as well, which is an array of paths to the part of the configuration that you want to install, using '#' as a separator.
 
 Usage for this services is:
 

--- a/README.md
+++ b/README.md
@@ -26,5 +26,5 @@ It works much like installConfig, but you need to pass in a "$targets" variable 
 Usage for this services is:
 
 ```
-\Drupal::service('distro_helper.updates')->installConfig($configid, $targets, $modulename, $dirname);
+\Drupal::service('distro_helper.updates')->updateConfig($configid, $targets, $modulename, $dirname);
 ```

--- a/README.md
+++ b/README.md
@@ -16,3 +16,15 @@ Usage for this services is:
 ```
 \Drupal::service('distro_helper.updates')->installConfig($configid, $modulename, $dirname);
 ```
+
+### updateConfig
+
+If you update configuration, but don't want to completely overwrite existing configuration on sites, use this method to do a targeted update of configuration.
+
+It works much like installConfig, but you need to pass in a "$targets" variable as well, which is an array of paths to the part of the configuration that you want to install, using ':' as a separator.
+
+Usage for this services is:
+
+```
+\Drupal::service('distro_helper.updates')->installConfig($configid, $targets, $modulename, $dirname);
+```

--- a/src/DistroHelperUpdates.php
+++ b/src/DistroHelperUpdates.php
@@ -153,7 +153,7 @@ class DistroHelperUpdates {
    *   The name of the configuration, like node.type.page, with no ".yml".
    * @param array $elementKeys
    *   An array of paths to the configuration elements within the config that
-   *   you want updated, using : as a separator. To set the UUID, you would just
+   *   you want updated, using # as a separator. To set the UUID, you would just
    *   pass ["UUID"]. To set a Block label, you would pass ["settings:label"].
    * @param string $module
    *   Module machine name that has the config file with the new value.
@@ -174,7 +174,7 @@ class DistroHelperUpdates {
     $config_data = $config->getRawData();
     foreach ($elementKeys as $elementKey) {
       $target = &$config_data;
-      $elementPath = explode(':', $elementKey);
+      $elementPath = explode('#', $elementKey);
       foreach ($elementPath as $step) {
         if (isset($newValue[$step])) {
           if (!isset($target[$step])) {

--- a/src/DistroHelperUpdates.php
+++ b/src/DistroHelperUpdates.php
@@ -7,9 +7,10 @@ use Drupal\Core\Config\StorageInterface;
 use Drupal\Core\Config\CachedStorage;
 use Drupal\Component\Serialization\Yaml;
 use Drupal\Component\Utility\Crypt;
+use Drupal\Core\Site\Settings;
 
 /**
- * Class DistroHelperUpdates.
+ * Provides a service to help with configuration management in distros.
  */
 class DistroHelperUpdates {
 
@@ -43,13 +44,12 @@ class DistroHelperUpdates {
     $this->configStorage = $config_storage;
   }
 
-
   /**
    * Helper function for managing new or changed configuration files.
    *
    * Use it in update hooks to install configuration from newly created or
-   * updated config files. Note that it is preferred to use the config factory for
-   * targeted updates rather than this ham-handed version: this is only the
+   * updated config files. Note that it is preferred to use the config factory
+   * for targeted updates rather than this ham-handed version: this is only the
    * preferred method for including new configuration in updates.
    *
    * The config factory for targeted updates, for example:
@@ -83,7 +83,6 @@ class DistroHelperUpdates {
     $updated = [];
     $created = [];
 
-    /** @var \Drupal\Core\Config\ConfigManagerInterface $config_manager */
     $config_manager = $this->configManager;
     $file = drupal_get_path('module', $module) . '/config/' . $directory . '/' . $config_name . '.yml';
     $raw = file_get_contents($file);
@@ -140,7 +139,7 @@ class DistroHelperUpdates {
    */
   public function exportConfig($config_name) {
     // Get our sync directory.
-    $config_dir = \Drupal\Core\Site\Settings::get('config_sync_directory');
+    $config_dir = Settings::get('config_sync_directory');
     $directory = realpath($config_dir);
     if (!is_writable($directory)) {
       return;


### PR DESCRIPTION
Adds a function that allows for low-disruption updates to config. You just pass in the config you want to update, where to find the new version, and the path to the parts of the config you want to pull in.