### PR TITLE
Fix update config behavior with multiple configs by resetting newValue on each loop.

### DIFF
--- a/src/DistroHelperUpdates.php
+++ b/src/DistroHelperUpdates.php
@@ -164,7 +164,7 @@ class DistroHelperUpdates {
    *   FALSE if the update failed, otherwise the updated configuration object.
    */
   public function updateConfig(string $configName, array $elementKeys, string $module, string $directory = 'install') {
-    $newValue = DistroHelperUpdates::loadConfigFromModule($configName, $module, $directory)['value'];
+    $ymlConfig = DistroHelperUpdates::loadConfigFromModule($configName, $module, $directory)['value'];
 
     $config = \Drupal::service('config.factory')->getEditable($configName);
     if ($config->isNew()) {
@@ -173,6 +173,7 @@ class DistroHelperUpdates {
     }
     $config_data = $config->getRawData();
     foreach ($elementKeys as $elementKey) {
+      $newValue = $ymlConfig;
       $target = &$config_data;
       $elementPath = explode('#', $elementKey);
       foreach ($elementPath as $step) {


### PR DESCRIPTION
Discovered on KMC. Since newValue gets pointed deep into the array during the loop, it's in the right place when we start over. Easy fix, but the bug causes the function to do nothing.