### PR TITLE
Issue #3 wrap the test for active storage in an if statement, and add…

### DIFF
--- a/src/DistroHelperUpdates.php
+++ b/src/DistroHelperUpdates.php
@@ -135,9 +135,6 @@ class DistroHelperUpdates {
     $sync_storage = $this->configStorageSync;
     $active_storage = $this->configStorage;
 
-    // Find out which config was saved.
-    $sync_storage->write($config_name, $active_storage->read($config_name));
-
     // Export configuration collections.
     foreach ($active_storage->getAllCollectionNames() as $collection) {
       $active_collection = $active_storage->createCollection($collection);


### PR DESCRIPTION
… a log message if it is not found.

Debugging -- that line is definitely necessary. Not all sites use collections, so the foreach below is only triggered for some.

So this adds the write line back, but tests for a value for that config in active storage, and if it's not found throws an error:

`Could not write the ../config/whatever.config.file.yml file. Did it successfully save to the database?`