### PR TITLE
Configurable writes & gentler errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ Provides a service "distro_helper.updates" with the following methods. Each of
 these methods writes configuration to the database and then writes the config
 out to the file system, if using file-based-config.
 
-This can produce confusing warnings on your server if file-based-config writing
-is not allowed there. You can disable this behavior in settings.php by adding:
+You can disable the "writing the config out to the file system" behavior in
+settings.php by adding:
 ```php
 $config['distro_helper']['disable_write'] = TRUE;
 ```
@@ -15,6 +15,8 @@ if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
   $config['distro_helper']['disable_write'] = TRUE;
 }
 ```
+Note that this is likely unnecessary, since this module checks to see if the
+file-based-config directory is writable before attempting a write, anyway.
 
 ### installConfig
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,20 @@
 ## What this module does
-Provides a service "distro_helper.updates" with the following methods:
+Provides a service "distro_helper.updates" with the following methods. Each of
+these methods writes configuration to the database and then writes the config
+out to the file system, if using file-based-config.
+
+This can produce confusing warnings on your server if file-based-config writing
+is not allowed there. You can disable this behavior in settings.php by adding:
+```php
+$config['distro_helper']['disable_write'] = TRUE;
+```
+
+For example, if using Pantheon, you might add it inside this conditional:
+```php
+if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
+  $config['distro_helper']['disable_write'] = TRUE;
+}
+```
 
 ### installConfig
 
@@ -13,7 +28,7 @@ If you run an update hook multiple times for testing purposes or on multiple env
 
 Usage for this services is:
 
-```
+```php
 \Drupal::service('distro_helper.updates')->installConfig($configid, $modulename, $dirname);
 ```
 
@@ -25,6 +40,6 @@ It works much like installConfig, but you need to pass in a "$targets" variable 
 
 Usage for this services is:
 
-```
+```php
 \Drupal::service('distro_helper.updates')->updateConfig($configid, $targets, $modulename, $dirname);
 ```

--- a/src/DistroHelperUpdates.php
+++ b/src/DistroHelperUpdates.php
@@ -124,6 +124,9 @@ class DistroHelperUpdates {
    *   The config to read.
    */
   public function exportConfig($config_name) {
+    if ($this->configManager->getConfigFactory()->get('distro_helper')->get('disable_write')) {
+      return;
+    }
     // Get our sync directory.
     $config_dir = Settings::get('config_sync_directory');
     $directory = realpath($config_dir);

--- a/src/DistroHelperUpdates.php
+++ b/src/DistroHelperUpdates.php
@@ -135,7 +135,7 @@ class DistroHelperUpdates {
     $sync_storage = $this->configStorageSync;
     $active_storage = $this->configStorage;
 
-    if ($this_file_in_active_storage = $active_storage->read($config_name)) {
+    if ($active_storage->read($config_name)) {
 
       // Find out which config was saved.
       $sync_storage->write($config_name, $active_storage->read($config_name));
@@ -144,20 +144,20 @@ class DistroHelperUpdates {
       foreach ($active_storage->getAllCollectionNames() as $collection) {
         $active_collection = $active_storage->createCollection($collection);
         $sync_collection = $sync_storage->createCollection($collection);
-        if ($this_file_in_active_storage = $active_collection->read($config_name)) {
+        if ( $active_collection->read($config_name)) {
           $sync_collection->write($config_name, $active_collection->read($config_name));
         }
         else {
-          \Drupal::logger('distro_helper')->error(
+          \Drupal::logger('distro_helper')->warning(
             'Could not write the @directory file. Did it successfully save to the database?',
             ['@directory' => $sync_collection->getFilePath($config_name)]);
         }
       }
     }
     else {
-      // Log: Could not write $config_name to the config sync directory. Did it successfully save to the database?
-      \Drupal::logger('distro_helper')->error(
-        'Could not write the @directory file. Did it successfully save to the database?',
+      // Log: Could not read $config_name from the config sync directory. Did it successfully save to the database?
+      \Drupal::logger('distro_helper')->warning(
+        'Could not read the @directory file. Is the configuration new?',
         ['@directory' => $sync_storage->getFilePath($config_name)]);
     }
   }


### PR DESCRIPTION
Forum site builders went into a tailspin when seeing the errors about writing out to the filesystem, so I decided to polish up that behavior a little. I changed the errors to warnings (seems sensible based on the error message we are giving) and added a way to disable the writing on Pantheon.