### PR TITLE
Install helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## What this module does
-Provides a service "distro_helper.updates" with the following methods:
+Provides two services: distro_helper.updates & distro_helper.install. Between them they have 3 methods to help with managing configuration during install or update, respectively.
 
-### installConfig
+### installConfig (distro_helper.updates)
 
 If you add new or updated configuration to a module's config folder, you need to provide an update hook to the site to let it know to pull in that new configuration.
 
@@ -17,7 +17,7 @@ Usage for this services is:
 \Drupal::service('distro_helper.updates')->installConfig($configid, $modulename, $dirname);
 ```
 
-### updateConfig
+### updateConfig (distro_helper.updates)
 
 If you update configuration, but don't want to completely overwrite existing configuration on sites, use this method to do a targeted update of configuration.
 
@@ -27,4 +27,20 @@ Usage for this services is:
 
 ```
 \Drupal::service('distro_helper.updates')->updateConfig($configid, $targets, $modulename, $dirname);
+```
+
+### syncUuids (distro_helper.install)
+
+Pushes uuids from your file based configuration into your site configuration. This is intended for fresh site installs where you want to see how your installed config differs from the config you get when you export a persistent database. The primary usage is to do this for ALL site config, but it is built to allow for a subset of configurations to be "synced" as well.
+
+Usage is:
+
+```
+\Drupal::service('distro_helper.install')->syncUUIDs($configs);
+```
+
+The standard way to call it, passing in ALL the file-based configs, is easy with the 'config.storage.export' service:
+
+```
+\Drupal::service('distro_helper.install')->syncUUIDs(\Drupal::service('config.storage.export')->listAll());
 ```

--- a/distro_helper.services.yml
+++ b/distro_helper.services.yml
@@ -7,4 +7,4 @@ services:
     arguments: ['@config.manager', '@config.storage.sync', '@config.storage']
   distro_helper.install:
     class: Drupal\distro_helper\DistroHelperInstall
-    arguments: [ '@config.manager', '@config.storage.sync', '@config.storage' ]
+    arguments: [ '@config.factory', '@config.storage.sync' ]

--- a/distro_helper.services.yml
+++ b/distro_helper.services.yml
@@ -5,3 +5,6 @@ services:
   distro_helper.updates:
     class: Drupal\distro_helper\DistroHelperUpdates
     arguments: ['@config.manager', '@config.storage.sync', '@config.storage']
+  distro_helper.install:
+    class: Drupal\distro_helper\DistroHelperInstall
+    arguments: [ '@config.manager', '@config.storage.sync', '@config.storage' ]

--- a/src/DistroHelperInstall.php
+++ b/src/DistroHelperInstall.php
@@ -38,7 +38,7 @@ class DistroHelperInstall {
    * @param array $configs
    *   The a set of configs as an array (leave off the .yml).
    */
-  public function syncUuids($configs) {
+  public function syncUuids(array $configs) {
     foreach ($configs as $configName) {
       // If new config exists in sync, match up the uuids.
       $sync_config = $this->configStorageSync->read($configName);

--- a/src/DistroHelperInstall.php
+++ b/src/DistroHelperInstall.php
@@ -35,11 +35,10 @@ class DistroHelperInstall {
   /**
    * Update the uuids from the just-installed site to match the config folder.
    *
-   * @param string $configs
-   *   The name of the config (its file name with the '.yml' part).
+   * @param array $configs
+   *   The a set of configs as an array (leave off the .yml).
    */
   public function syncUuids($configs) {
-    // Foreach config in the system.
     foreach ($configs as $configName) {
       // If new config exists in sync, match up the uuids.
       $sync_config = $this->configStorageSync->read($configName);

--- a/src/DistroHelperInstall.php
+++ b/src/DistroHelperInstall.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\distro_helper;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Config\ConfigManagerInterface;
 use Drupal\Core\Config\StorageInterface;
 use Drupal\Core\Config\CachedStorage;
@@ -17,9 +18,9 @@ class DistroHelperInstall {
   /**
    * Drupal\Core\Config\ConfigManagerInterface definition.
    *
-   * @var \Drupal\Core\Config\ConfigManagerInterface
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
    */
-  protected $configManager;
+  protected $configFactory;
 
   /**
    * Drupal\Core\Config\StorageInterface definition.
@@ -29,19 +30,11 @@ class DistroHelperInstall {
   protected $configStorageSync;
 
   /**
-   * Drupal\Core\Config\CachedStorage definition.
-   *
-   * @var \Drupal\Core\Config\CachedStorage
-   */
-  protected $configStorage;
-
-  /**
    * Constructs a new DistroHelperUpdates object.
    */
-  public function __construct(ConfigManagerInterface $config_manager, StorageInterface $config_storage_sync, CachedStorage $config_storage) {
-    $this->configManager = $config_manager;
+  public function __construct(ConfigFactoryInterface $config_factory, StorageInterface $config_storage_sync) {
+    $this->configFactory = $config_factory;
     $this->configStorageSync = $config_storage_sync;
-    $this->configStorage = $config_storage;
   }
 
   /**
@@ -66,7 +59,7 @@ class DistroHelperInstall {
     foreach($configs as $configName) {
       // If new config exists in sync, match up the uuids.
       $sync_config = $this->configStorageSync->read($configName);
-      $entity = \Drupal::service('config.factory')->getEditable($configName);
+      $entity = $this->configFactory->getEditable($configName);
 
       if (!empty($sync_config['uuid'])) {
         $entity->set('uuid', $sync_config['uuid']);

--- a/src/DistroHelperInstall.php
+++ b/src/DistroHelperInstall.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Drupal\distro_helper;
+
+use Drupal\Core\Config\ConfigManagerInterface;
+use Drupal\Core\Config\StorageInterface;
+use Drupal\Core\Config\CachedStorage;
+use Drupal\Component\Serialization\Yaml;
+use Drupal\Component\Utility\Crypt;
+use Drupal\Core\Site\Settings;
+
+/**
+ * Provides a service to help with configuration management in distros on install.
+ */
+class DistroHelperInstall {
+
+  /**
+   * Drupal\Core\Config\ConfigManagerInterface definition.
+   *
+   * @var \Drupal\Core\Config\ConfigManagerInterface
+   */
+  protected $configManager;
+
+  /**
+   * Drupal\Core\Config\StorageInterface definition.
+   *
+   * @var \Drupal\Core\Config\StorageInterface
+   */
+  protected $configStorageSync;
+
+  /**
+   * Drupal\Core\Config\CachedStorage definition.
+   *
+   * @var \Drupal\Core\Config\CachedStorage
+   */
+  protected $configStorage;
+
+  /**
+   * Constructs a new DistroHelperUpdates object.
+   */
+  public function __construct(ConfigManagerInterface $config_manager, StorageInterface $config_storage_sync, CachedStorage $config_storage) {
+    $this->configManager = $config_manager;
+    $this->configStorageSync = $config_storage_sync;
+    $this->configStorage = $config_storage;
+  }
+
+  /**
+   * Helper function to update the uuids from the config folder to match the just-installed site.
+   *
+   * @param string $configName
+   *   The name of the config (its file name with the '.yml' part).
+   * @param string $module
+   *   Module machine name that has the config files.
+   * @param string $directory
+   *   Usually "install" but sometimes "optional".
+   * @param bool $update
+   *   Whether or not to update the config if it already exists.
+   *
+   * @return array[]
+   *   Two arrays of 'updated' and 'created' configurations.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  public function syncUUIDs($configs) {
+    // Foreach config in the system.
+    foreach($configs as $config) {
+      $value['_core']['default_config_hash'] = Crypt::hashBase64(serialize($value));
+      $entity = $entity_storage->createFromStorageRecord($value);
+      // If new config exists in sync, match up the uuids.
+      $sync_config = $this->configStorageSync->read($configName);
+
+      if (!empty($sync_config['uuid'])) {
+        $entity->set('uuid', $sync_config['uuid']);
+      }
+      $entity->save();
+    }
+  }
+
+
+}

--- a/src/DistroHelperInstall.php
+++ b/src/DistroHelperInstall.php
@@ -45,7 +45,7 @@ class DistroHelperInstall {
   }
 
   /**
-   * Helper function to update the uuids from the config folder to match the just-installed site.
+   * Helper function to update the uuids from the just-installed site to match the config folder.
    *
    * @param string $configName
    *   The name of the config (its file name with the '.yml' part).
@@ -63,14 +63,16 @@ class DistroHelperInstall {
    */
   public function syncUUIDs($configs) {
     // Foreach config in the system.
-    foreach($configs as $config) {
-      $value['_core']['default_config_hash'] = Crypt::hashBase64(serialize($value));
-      $entity = $entity_storage->createFromStorageRecord($value);
+    foreach($configs as $configName) {
       // If new config exists in sync, match up the uuids.
       $sync_config = $this->configStorageSync->read($configName);
+      $entity = \Drupal::service('config.factory')->getEditable($configName);
 
       if (!empty($sync_config['uuid'])) {
         $entity->set('uuid', $sync_config['uuid']);
+      }
+      if (isset($sync_config['_core']['default_config_hash'])) {
+        $entity->set('_core', $sync_config['_core']);
       }
       $entity->save();
     }

--- a/src/DistroHelperInstall.php
+++ b/src/DistroHelperInstall.php
@@ -77,6 +77,4 @@ class DistroHelperInstall {
       $entity->save();
     }
   }
-
-
 }

--- a/src/DistroHelperInstall.php
+++ b/src/DistroHelperInstall.php
@@ -3,15 +3,10 @@
 namespace Drupal\distro_helper;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
-use Drupal\Core\Config\ConfigManagerInterface;
 use Drupal\Core\Config\StorageInterface;
-use Drupal\Core\Config\CachedStorage;
-use Drupal\Component\Serialization\Yaml;
-use Drupal\Component\Utility\Crypt;
-use Drupal\Core\Site\Settings;
 
 /**
- * Provides a service to help with configuration management in distros on install.
+ * Provides a service to help with config management in distros on install.
  */
 class DistroHelperInstall {
 
@@ -38,25 +33,14 @@ class DistroHelperInstall {
   }
 
   /**
-   * Helper function to update the uuids from the just-installed site to match the config folder.
+   * Update the uuids from the just-installed site to match the config folder.
    *
-   * @param string $configName
+   * @param string $configs
    *   The name of the config (its file name with the '.yml' part).
-   * @param string $module
-   *   Module machine name that has the config files.
-   * @param string $directory
-   *   Usually "install" but sometimes "optional".
-   * @param bool $update
-   *   Whether or not to update the config if it already exists.
-   *
-   * @return array[]
-   *   Two arrays of 'updated' and 'created' configurations.
-   *
-   * @throws \Drupal\Core\Entity\EntityStorageException
    */
-  public function syncUUIDs($configs) {
+  public function syncUuids($configs) {
     // Foreach config in the system.
-    foreach($configs as $configName) {
+    foreach ($configs as $configName) {
       // If new config exists in sync, match up the uuids.
       $sync_config = $this->configStorageSync->read($configName);
       $entity = $this->configFactory->getEditable($configName);
@@ -70,4 +54,5 @@ class DistroHelperInstall {
       $entity->save();
     }
   }
+
 }


### PR DESCRIPTION
Adds the `syncUuids` method, part of a new service "distro_helper.install", which can push all the uuids from your "../config" directory up to the config stored in your database without changing any of the other config. 

This is good for fresh site installs where you want to see how your installed config differs from the config you get when you export a persistent database.

You can call it like this:
```
\Drupal::service('distro_helper.install')->syncUUIDs(\Drupal::service('config.storage.export')->listAll());
```

I left the config that you'd want to update as an array that gets passed to the method. This feels more flexible than forcing this method to always update all config.

Testing instructions are in https://github.com/United-Philanthropy-Forum/kmc-tester/pull/345.