### PR TITLE
Simple configuration does not have a type, so it should be loaded and…

### DIFF
--- a/src/DistroHelperUpdates.php
+++ b/src/DistroHelperUpdates.php
@@ -84,6 +84,7 @@ class DistroHelperUpdates {
   public function installConfig(string $configName, string $module, string $directory = 'install', bool $update = FALSE) {
     $updated = [];
     $created = [];
+    $entity = FALSE;
 
     $config_manager = $this->configManager;
     $config = DistroHelperUpdates::loadConfigFromModule($configName, $module, $directory);

--- a/src/DistroHelperUpdates.php
+++ b/src/DistroHelperUpdates.php
@@ -81,15 +81,17 @@ class DistroHelperUpdates {
     $value = $config['value'];
 
     $type = $config_manager->getEntityTypeIdByName(basename($config['file']));
-    /** @var \Drupal\Core\Entity\EntityTypeManager $entity_manager */
-    $entity_manager = $config_manager->getEntityTypeManager();
-    $definition = $entity_manager->getDefinition($type);
-    $id_key = $definition->getKey('id');
-    $id = $value[$id_key];
+    if ($type) {
+      /** @var \Drupal\Core\Entity\EntityTypeManager $entity_manager */
+      $entity_manager = $config_manager->getEntityTypeManager();
+      $definition = $entity_manager->getDefinition($type);
+      $id_key = $definition->getKey('id');
+      $id = $value[$id_key];
 
-    /** @var \Drupal\Core\Config\Entity\ConfigEntityStorage $entity_storage */
-    $entity_storage = $entity_manager->getStorage($type);
-    $entity = $entity_storage->load($id);
+      /** @var \Drupal\Core\Config\Entity\ConfigEntityStorage $entity_storage */
+      $entity_storage = $entity_manager->getStorage($type);
+      $entity = $entity_storage->load($id);
+    }
     if ($entity) {
       if ($update) {
         $entity = $entity_storage->updateFromStorageRecord($entity, $value);
@@ -99,15 +101,15 @@ class DistroHelperUpdates {
     }
     else {
       $value['_core']['default_config_hash'] = Crypt::hashBase64(serialize($value));
-      $entity = $entity_storage->createFromStorageRecord($value);
+      $config = \Drupal::service('config.factory')->getEditable($configName);
+      $config->setData($value);
       // If new config exists in sync, match up the uuids.
       $sync_config = $this->configStorageSync->read($configName);
-
       if (!empty($sync_config['uuid'])) {
-        $entity->set('uuid', $sync_config['uuid']);
+        $config->set('uuid', $sync_config['uuid']);
       }
-      $entity->save();
-      $created[] = $id;
+      $config->save();
+      $created[] = $configName;
     }
     // If possible, immediately export the updated files.
     $this->exportConfig($configName);

--- a/src/DistroHelperUpdates.php
+++ b/src/DistroHelperUpdates.php
@@ -110,7 +110,7 @@ class DistroHelperUpdates {
     }
     else {
       $value['_core']['default_config_hash'] = Crypt::hashBase64(serialize($value));
-      $config = \Drupal::service('config.factory')->getEditable($configName);
+      $config = $this->configManager->getConfigFactory()->getEditable($configName);
       $config->setData($value);
       // If new config exists in sync, match up the uuids.
       $sync_config = $this->configStorageSync->read($configName);


### PR DESCRIPTION
… saved using a simpler method.

In short, if you try to use `installConfig` on a simple settings file, it will fail with the error Olivier mentions in https://github.com/thinkshout/distro_helper/issues/10. I was using it to try to install `ckeditor_accordion.settings` for example, but I've also encountered it on the `content_snippets.settings` file. It will be an issue on any of those `.settings` files.

I encountered a problem where using configImport on a simple settings file during update hooks did not work, and that's because the don't have a `type` as returned by `$config_manager->getEntityTypeIdByName`. That means there is no way to pull up `entity_storage` which means `$entity_storage->createFromStorageRecord($value);` also does not work.