### PR TITLE
PR feedback.

### DIFF
--- a/drupal/composer.json
+++ b/drupal/composer.json
@@ -19,7 +19,7 @@
         "drupal/core-composer-scaffold": "^9.1",
         "drupal/core-project-message": "^9.1",
         "drupal/core-recommended": "^9.1",
-        "thinkshout/distro_helper": "dev-main"
+        "thinkshout/distro_helper": "dev-issue-exit-feedback"
     },
     "require-dev": {
         "drupal/coder": "^8.3",

--- a/src/DistroHelperUpdates.php
+++ b/src/DistroHelperUpdates.php
@@ -9,6 +9,7 @@ use Drupal\Component\Serialization\Yaml;
 use Drupal\Component\Utility\Crypt;
 use Drupal\Core\Site\Settings;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 
 /**
  * Provides a service to help with configuration management in distros.
@@ -275,7 +276,7 @@ class DistroHelperUpdates {
       }
       if ($depth < count($elementPath)) {
         // We didn't find the full path given in our new config. Throw message.
-        $this->loggerErrors[] = t('Could not find a value nested at @config', ['@config' => implode('.', $elementPath)]);
+        $this->loggerErrors[] = new TranslatableMarkup('Could not find a value nested at @config', ['@config' => implode('.', $elementPath)]);
       }
       elseif ($newValue === NULL) {
         unset($target[$step]);

--- a/src/DistroHelperUpdates.php
+++ b/src/DistroHelperUpdates.php
@@ -45,10 +45,10 @@ class DistroHelperUpdates {
   protected $logger;
 
   /**
-   * Logger errors as an array found in syncActiveConfigFromSavedConfigByKeys.
+   * Logger errors as an array that can be printed out.
    *
    * Using the drupal $logger factory in syncActiveConfigFromSavedConfigByKeys
-   * would force us to change our test to a Kernel test.
+   * would force us to change our test to a slower Kernel test.
    *
    * @var array
    */

--- a/src/DistroHelperUpdates.php
+++ b/src/DistroHelperUpdates.php
@@ -292,6 +292,7 @@ class DistroHelperUpdates {
    * Returns the logger errors for unit tests.
    *
    * @return array
+   *   The array of all errors found.
    */
   public function getLoggerErrors(): array {
     return $this->loggerErrors;

--- a/src/DistroHelperUpdates.php
+++ b/src/DistroHelperUpdates.php
@@ -201,7 +201,7 @@ class DistroHelperUpdates {
     }
     $raw_active_config = $active_config->getRawData();
     $raw_active_config = $this->syncActiveConfigFromSavedConfigByKeys($raw_active_config, $new_config, $elementKeys);
-    foreach($this->loggerErrors as $error) {
+    foreach ($this->loggerErrors as $error) {
       $this->logger->error($error->render());
     }
     $active_config->setData($raw_active_config)->save();
@@ -275,7 +275,7 @@ class DistroHelperUpdates {
       }
       if ($depth < count($elementPath)) {
         // We didn't find the full path given in our new config. Throw message.
-        $this->loggerErrors[] =  t('Could not find a value nested at @config', ['@config' => implode('.', $elementPath)]);
+        $this->loggerErrors[] = t('Could not find a value nested at @config', ['@config' => implode('.', $elementPath)]);
       }
       elseif ($newValue === NULL) {
         unset($target[$step]);

--- a/src/DistroHelperUpdates.php
+++ b/src/DistroHelperUpdates.php
@@ -39,7 +39,7 @@ class DistroHelperUpdates {
   /**
    * A logger instance.
    *
-   * @var \Drupal\Core\Logger\LoggerChannelFactory
+   * @var \Drupal\Core\Logger\LoggerChannelFactoryInterface
    */
   protected $logger;
 

--- a/src/DistroHelperUpdates.php
+++ b/src/DistroHelperUpdates.php
@@ -183,6 +183,9 @@ class DistroHelperUpdates {
     $active_config = $this->configManager->getConfigFactory()->getEditable($configName);
     if ($active_config->isNew()) {
       // Can't update nonexistent config.
+      $this->logger->error(
+        'No active config found for @configName. Use installConfig to import config that does not already exist in your database.',
+        ['@config' => $configName]);
       return FALSE;
     }
     $raw_active_config = $active_config->getRawData();
@@ -257,9 +260,8 @@ class DistroHelperUpdates {
         }
       }
       if ($depth < count($elementPath)) {
-        // @todo If this is the case, we didn't find the full path given in our
-        // new config. Throw message?
-        $this->logger->warning(
+        // We didn't find the full path given in our new config. Throw message.
+        $this->logger->error(
           'Could not find a value nested at @config',
           ['@config' => $elementKeys]);
       }

--- a/src/DistroHelperUpdates.php
+++ b/src/DistroHelperUpdates.php
@@ -196,7 +196,7 @@ class DistroHelperUpdates {
     if ($active_config->isNew()) {
       // Can't update nonexistent config.
       $this->logger->error(
-        'No active config found for @configName. Use installConfig to import config that does not already exist in your database.',
+        'No active config found for @configName in updateConfig(). Use installConfig() to import config that does not already exist in your database.',
         ['@config' => $configName]);
       return FALSE;
     }

--- a/tests/src/Unit/DistroHelperUpdatesTest.php
+++ b/tests/src/Unit/DistroHelperUpdatesTest.php
@@ -141,6 +141,10 @@ class DistroHelperUpdatesTest extends UnitTestCase {
     // Test: Trying to update a path that does not exist.
     $bad_update = $this->distroHelperUpdates->syncActiveConfigFromSavedConfigByKeys($this->ymlOld, $this->ymlNew, ['the_final_little_piggy#went weeeeee all the way home#distance']);
     $this->assertEquals($bad_update, $this->ymlOld, 'Tried to update a non-existent path, old array unchanged.');
+    // Proves that bad requests get logged.
+    $this->assertEquals($this->distroHelperUpdates->getLoggerErrors()[0],
+      t('Could not find a value nested at @config', ['@config' => 'the_final_little_piggy.went weeeeee all the way home.distance'])
+    );
 
     // Test: Trying to update a path that does not exist AND real paths.
     $partially_bad_update = $this->distroHelperUpdates->syncActiveConfigFromSavedConfigByKeys($this->ymlOld, $this->ymlNew, [
@@ -163,6 +167,11 @@ class DistroHelperUpdatesTest extends UnitTestCase {
         ],
       ],
     ], 'Part of a bad update succeeded.');
+
+    // Proves that bad requests get logged.
+    $this->assertEquals($this->distroHelperUpdates->getLoggerErrors()[1],
+      t('Could not find a value nested at @config', ['@config' => 'the_final_little_piggy.went weeeeee all the way home.distance'])
+    );
   }
 
   /**

--- a/tests/src/Unit/DistroHelperUpdatesTest.php
+++ b/tests/src/Unit/DistroHelperUpdatesTest.php
@@ -7,7 +7,7 @@ use Drupal\Core\Config\ConfigManagerInterface;
 use Drupal\Core\Config\StorageInterface;
 use Drupal\Tests\UnitTestCase;
 use Drupal\distro_helper\DistroHelperUpdates;
-use Drupal\Core\Logger\LoggerChannelFactory;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 
 /**
  * Simple test to ensure that asserts pass.
@@ -74,7 +74,7 @@ class DistroHelperUpdatesTest extends UnitTestCase {
     $config_manager = $this->prophesize(ConfigManagerInterface::class);
     $config_storage_sync = $this->prophesize(StorageInterface::class);
     $config_storage = $this->prophesize(CachedStorage::class);
-    $logger = $this->prophesize(LoggerChannelFactory::class);
+    $logger = $this->prophesize(LoggerChannelFactoryInterface::class);
     $this->distroHelperUpdates = new DistroHelperUpdates($config_manager->reveal(), $config_storage_sync->reveal(), $config_storage->reveal(), $logger->reveal());
   }
 

--- a/tests/src/Unit/DistroHelperUpdatesTest.php
+++ b/tests/src/Unit/DistroHelperUpdatesTest.php
@@ -8,6 +8,7 @@ use Drupal\Core\Config\StorageInterface;
 use Drupal\Tests\UnitTestCase;
 use Drupal\distro_helper\DistroHelperUpdates;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 
 /**
  * Simple test to ensure that asserts pass.
@@ -143,7 +144,7 @@ class DistroHelperUpdatesTest extends UnitTestCase {
     $this->assertEquals($bad_update, $this->ymlOld, 'Tried to update a non-existent path, old array unchanged.');
     // Proves that bad requests get logged.
     $this->assertEquals($this->distroHelperUpdates->getLoggerErrors()[0],
-      t('Could not find a value nested at @config', ['@config' => 'the_final_little_piggy.went weeeeee all the way home.distance'])
+      new TranslatableMarkup('Could not find a value nested at @config', ['@config' => 'the_final_little_piggy.went weeeeee all the way home.distance'])
     );
 
     // Test: Trying to update a path that does not exist AND real paths.
@@ -170,7 +171,7 @@ class DistroHelperUpdatesTest extends UnitTestCase {
 
     // Proves that bad requests get logged.
     $this->assertEquals($this->distroHelperUpdates->getLoggerErrors()[1],
-      t('Could not find a value nested at @config', ['@config' => 'the_final_little_piggy.went weeeeee all the way home.distance'])
+       new TranslatableMarkup('Could not find a value nested at @config', ['@config' => 'the_final_little_piggy.went weeeeee all the way home.distance'])
     );
   }
 


### PR DESCRIPTION
from https://github.com/thinkshout/distro_helper/pull/12#pullrequestreview-1431387283.

Truly obnoxiously, it's very hard to write unit tests when you refer to the logger functionality in your function, so there is a bit of a workaround in here. It's possible that giving up and turning these into Kernal tests wouldn't be the end of the world, or be as slow as I suspect they would be, but that's a skill I haven't yet learned. I'll make a followup ticket for it.