### PR TITLE
Syncing uuids.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ Pushes uuids from your file based configuration into your site configuration. Th
 Usage is:
 
 ```
-\Drupal::service('distro_helper.install')->syncUUIDs($configs);
+\Drupal::service('distro_helper.updates')->syncUUIDs($configs);
 ```
 
 The standard way to call it, passing in ALL the file-based configs, is easy with the 'config.storage.export' service:
 
 ```
-\Drupal::service('distro_helper.install')->syncUUIDs(\Drupal::service('config.storage.export')->listAll());
+\Drupal::service('distro_helper.updates')->syncUUIDs(\Drupal::service('config.storage.export')->listAll());
 ```

--- a/distro_helper.services.yml
+++ b/distro_helper.services.yml
@@ -4,7 +4,7 @@ services:
     arguments: ['distro_helper']
   distro_helper.updates:
     class: Drupal\distro_helper\DistroHelperUpdates
-    arguments: ['@config.manager', '@config.storage.sync', '@config.storage', '@extension.path.resolver']
+    arguments: ['@config.manager', '@config.storage.sync', '@config.storage', '@extension.path.resolver', '@config.factory',]
   distro_helper.install:
     class: Drupal\distro_helper\DistroHelperInstall
     arguments: [ '@config.factory', '@config.storage.sync' ]

--- a/distro_helper.services.yml
+++ b/distro_helper.services.yml
@@ -7,4 +7,4 @@ services:
     arguments: ['@config.manager', '@config.storage.sync', '@config.storage', '@extension.path.resolver', '@config.factory',]
   distro_helper.install:
     class: Drupal\distro_helper\DistroHelperInstall
-    arguments: [ '@config.factory', '@config.storage.sync' ]
+    arguments: [ '@distro_helper.updates' ]

--- a/distro_helper.services.yml
+++ b/distro_helper.services.yml
@@ -4,7 +4,7 @@ services:
     arguments: ['distro_helper']
   distro_helper.updates:
     class: Drupal\distro_helper\DistroHelperUpdates
-    arguments: ['@config.manager', '@config.storage.sync', '@config.storage', '@extension.path.resolver', '@config.factory',]
+    arguments: ['@config.manager', '@config.storage.sync', '@config.storage', '@extension.path.resolver', '@config.factory']
   distro_helper.install:
     class: Drupal\distro_helper\DistroHelperInstall
     arguments: [ '@distro_helper.updates' ]

--- a/src/DistroHelperInstall.php
+++ b/src/DistroHelperInstall.php
@@ -2,34 +2,27 @@
 
 namespace Drupal\distro_helper;
 
-use Drupal\Core\Config\ConfigFactoryInterface;
-use Drupal\Core\Config\StorageInterface;
+use Drupal\distro_helper\DistroHelperUpdates;
 
 /**
  * Provides a service to help with config management in distros on install.
+ *
+ * @deprecated in %deprecation-version% and is removed from %removal-version%. %extra-info%.
  */
 class DistroHelperInstall {
 
   /**
-   * Drupal\Core\Config\ConfigManagerInterface definition.
+   * Drupal\distro_helper\DistroHelperUpdates definition.
    *
-   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   * @var \Drupal\distro_helper\DistroHelperUpdates
    */
-  protected $configFactory;
-
-  /**
-   * Drupal\Core\Config\StorageInterface definition.
-   *
-   * @var \Drupal\Core\Config\StorageInterface
-   */
-  protected $configStorageSync;
+  protected $distroHelperUpdates;
 
   /**
    * Constructs a new DistroHelperUpdates object.
    */
-  public function __construct(ConfigFactoryInterface $config_factory, StorageInterface $config_storage_sync) {
-    $this->configFactory = $config_factory;
-    $this->configStorageSync = $config_storage_sync;
+  public function __construct(DistroHelperUpdates $distro_helper_updates) {
+    $this->distroHelperUpdates = $distro_helper_updates;
   }
 
   /**
@@ -39,19 +32,7 @@ class DistroHelperInstall {
    *   The a set of configs as an array (leave off the .yml).
    */
   public function syncUuids(array $configs) {
-    foreach ($configs as $configName) {
-      // If new config exists in sync, match up the uuids.
-      $sync_config = $this->configStorageSync->read($configName);
-      $entity = $this->configFactory->getEditable($configName);
-
-      if (!empty($sync_config['uuid'])) {
-        $entity->set('uuid', $sync_config['uuid']);
-      }
-      if (isset($sync_config['_core']['default_config_hash'])) {
-        $entity->set('_core', $sync_config['_core']);
-      }
-      $entity->save();
-    }
+      $this->distroHelperUpdates->syncUUIDs(\Drupal::service('config.storage.export')->listAll());
   }
 
 }

--- a/src/DistroHelperInstall.php
+++ b/src/DistroHelperInstall.php
@@ -2,12 +2,15 @@
 
 namespace Drupal\distro_helper;
 
-use Drupal\distro_helper\DistroHelperUpdates;
+// @codingStandardsIgnoreFile
 
 /**
  * Provides a service to help with config management in distros on install.
  *
- * @deprecated in %deprecation-version% and is removed from %removal-version%. %extra-info%.
+ * @deprecated in distro_helper:1.0.5 and is removed from distro_helper:2.0.0.
+ * @see https://github.com/thinkshout/distro_helper/issues/21
+ * Use \Drupal\distro_helper\DistroHelperUpdates::syncUuids instead.
+ * Example usage: \Drupal::service('distro_helper.updates')->syncUUIDs($configs);
  */
 class DistroHelperInstall {
 
@@ -32,7 +35,7 @@ class DistroHelperInstall {
    *   The a set of configs as an array (leave off the .yml).
    */
   public function syncUuids(array $configs) {
-      $this->distroHelperUpdates->syncUUIDs(\Drupal::service('config.storage.export')->listAll());
+    $this->distroHelperUpdates->syncUUIDs(\Drupal::service('config.storage.export')->listAll());
   }
 
 }

--- a/src/DistroHelperUpdates.php
+++ b/src/DistroHelperUpdates.php
@@ -147,7 +147,7 @@ class DistroHelperUpdates {
       $config->save();
       $created[] = $configName;
     }
-      \Drupal::service('distro_helper.install')->syncUUIDs([$configName]);
+    \Drupal::service('distro_helper.install')->syncUUIDs([$configName]);
     // If possible, immediately export the updated files.
     $this->exportConfig($configName);
     return [

--- a/src/DistroHelperUpdates.php
+++ b/src/DistroHelperUpdates.php
@@ -147,6 +147,7 @@ class DistroHelperUpdates {
       $config->save();
       $created[] = $configName;
     }
+      \Drupal::service('distro_helper.install')->syncUUIDs([$configName]);
     // If possible, immediately export the updated files.
     $this->exportConfig($configName);
     return [

--- a/src/DistroHelperUpdates.php
+++ b/src/DistroHelperUpdates.php
@@ -5,6 +5,7 @@ namespace Drupal\distro_helper;
 use Drupal\Component\Serialization\Yaml;
 use Drupal\Component\Utility\Crypt;
 use Drupal\Core\Config\CachedStorage;
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Config\ConfigManagerInterface;
 use Drupal\Core\Config\StorageInterface;
 use Drupal\Core\Extension\ExtensionPathResolver;

--- a/src/DistroHelperUpdates.php
+++ b/src/DistroHelperUpdates.php
@@ -56,13 +56,13 @@ class DistroHelperUpdates {
   protected $extensionPathResolver;
 
   /**
-  * Drupal\Core\Config\ConfigManagerInterface definition.
-  *
-  * @var \Drupal\Core\Config\ConfigFactoryInterface
-  */
+   * Drupal\Core\Config\ConfigManagerInterface definition.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
   protected $configFactory;
 
-    /**
+  /**
    * Constructs a new DistroHelperUpdates object.
    */
   public function __construct(ConfigManagerInterface $config_manager, StorageInterface $config_storage_sync, CachedStorage $config_storage, ExtensionPathResolver $extension_path_resolver, ConfigFactoryInterface $config_factory) {
@@ -337,26 +337,26 @@ class DistroHelperUpdates {
     return $this->loggerErrors;
   }
 
-    /**
-     * Update the uuids from the just-installed site to match the config folder.
-     *
-     * @param array $configs
-     *   The a set of configs as an array (leave off the .yml).
-     */
-    public function syncUuids(array $configs) {
-        foreach ($configs as $configName) {
-            // If new config exists in sync, match up the uuids.
-            $sync_config = $this->configStorageSync->read($configName);
-            $entity = $this->configFactory->getEditable($configName);
+  /**
+   * Update the uuids from the just-installed site to match the config folder.
+   *
+   * @param array $configs
+   *   The a set of configs as an array (leave off the .yml).
+   */
+  public function syncUuids(array $configs) {
+    foreach ($configs as $configName) {
+      // If new config exists in sync, match up the uuids.
+      $sync_config = $this->configStorageSync->read($configName);
+      $entity = $this->configFactory->getEditable($configName);
 
-            if (!empty($sync_config['uuid'])) {
-                $entity->set('uuid', $sync_config['uuid']);
-            }
-            if (isset($sync_config['_core']['default_config_hash'])) {
-                $entity->set('_core', $sync_config['_core']);
-            }
-            $entity->save();
-        }
+      if (!empty($sync_config['uuid'])) {
+        $entity->set('uuid', $sync_config['uuid']);
+      }
+      if (isset($sync_config['_core']['default_config_hash'])) {
+        $entity->set('_core', $sync_config['_core']);
+      }
+      $entity->save();
     }
+  }
 
 }

--- a/tests/src/Unit/DistroHelperUpdatesTest.php
+++ b/tests/src/Unit/DistroHelperUpdatesTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\Tests\distro_helper\Unit;
 
 use Drupal\Core\Config\CachedStorage;
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Config\ConfigManagerInterface;
 use Drupal\Core\Config\StorageInterface;
 use Drupal\Core\Extension\ExtensionPathResolver;
@@ -76,7 +77,8 @@ class DistroHelperUpdatesTest extends UnitTestCase {
     $config_storage_sync = $this->prophesize(StorageInterface::class);
     $config_storage = $this->prophesize(CachedStorage::class);
     $extension_path_resolver = $this->prophesize(ExtensionPathResolver::class);
-    $this->distroHelperUpdates = new DistroHelperUpdates($config_manager->reveal(), $config_storage_sync->reveal(), $config_storage->reveal(), $extension_path_resolver->reveal());
+    $config_factory = $this->prophesize(ConfigFactoryInterface::class);
+    $this->distroHelperUpdates = new DistroHelperUpdates($config_manager->reveal(), $config_storage_sync->reveal(), $config_storage->reveal(), $extension_path_resolver->reveal(), $config_factory->reveal());
   }
 
   /**


### PR DESCRIPTION
Prevents the problem where your uuids get written the first time you run an update hook, then rewritten every time you run it subsequently. Also stops you from deleting newly-created fields the second time you do a `drush updb` and `drush cim`